### PR TITLE
Added a flag for end station for direction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 build/
 dist/
+.idea/

--- a/pybart/draw.py
+++ b/pybart/draw.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from textwrap import TextWrapper
-
+import re
 
 class EstimateDrawer(object):
     """Class for drawing BART estimates on the terminal."""
@@ -8,14 +8,16 @@ class EstimateDrawer(object):
     stations = None
     window = None
     wrapper = None
+    end_station = None
 
     prev_lines = 0
 
-    def __init__(self, bart, stations, window):
+    def __init__(self, bart, stations, window, end_station):
         self.bart = bart
         self.stations = stations
         self.window = window
         self.wrapper = TextWrapper()
+        self.end_station = end_station
 
     def _format_minutes(self, minutes):
         """Return the minutes estimate formatted with its color."""
@@ -84,8 +86,12 @@ class EstimateDrawer(object):
             for departure in station.iterfind('etd'):
                 y += 1
                 destination = departure.find('destination').text
-                self.window.addstr(y, 0, destination + ' ' * (
-                    self.window.spacing - len(destination)))
+                if self.end_station and re.match('.*' + self.end_station + '.*', destination, re.I):
+                    self.window.addstr(y, 0, destination + ' ' * (
+                        self.window.spacing - len(destination)), reverse=True)
+                else:
+                    self.window.addstr(y, 0, destination + ' ' * (
+                            self.window.spacing - len(destination)))
                 x = self.window.spacing
 
                 # Display all estimates for a destination on the same line

--- a/pybart/main.py
+++ b/pybart/main.py
@@ -33,6 +33,8 @@ def main():
     )
     parser.add_argument(
         '-v', '--version', action='version', version=pybart.__version__)
+    parser.add_argument(
+        '-d', '--direction', type=str, help='highlight the direction in the estimation list')
 
     # Add parsers for sub-commands
     subparsers = parser.add_subparsers(title='commands')
@@ -131,6 +133,7 @@ def display_estimates(args, parser):
     # Use the default stations if no arguments were passed in
     try:
         stations = args.stations
+        end_station = args.direction
     except AttributeError:
         stations = settings.BART_STATIONS
 
@@ -140,7 +143,7 @@ def display_estimates(args, parser):
         exit(1)
 
     with Window(settings.REFRESH_INTERVAL, settings.TOTAL_COLUMNS) as window:
-        drawer = EstimateDrawer(BART(), stations, window)
+        drawer = EstimateDrawer(BART(), stations, window, end_station)
         char = ''
 
         # Keep running until 'q' is pressed to exit or an error occurs

--- a/pybart/utils.py
+++ b/pybart/utils.py
@@ -70,12 +70,13 @@ class Window(object):
         _, self.width = self.window.getmaxyx()
         self.spacing = self.width // self.total_columns
 
-    def addstr(self, y, x, string, color_name='', bold=False):
+    def addstr(self, y, x, string, color_name='', bold=False, reverse=False):
         """Add a string with optional color and boldness."""
         color = self._get_color(color_name)
         if bold:
             color |= curses.A_BOLD
-
+        if reverse:
+            color |= curses.A_REVERSE
         try:
             self.window.addstr(y, x, string, color)
         except curses.error:


### PR DESCRIPTION
Hi Eric, 

I wanted to highlight the direction of the train in the real time departures section and added a flag to do that (-d).

Now when you do:
`bart -d millb est embr `
It highlights the Millbrae direction for the Embarcadero station.

If you find it useful (And it works for you) feel free to merge it ;)

<img width="562" alt="screen shot 2018-01-31 at 8 42 04 pm" src="https://user-images.githubusercontent.com/229203/35661479-4facf93e-06c7-11e8-8340-0457574adfe5.png">

Cheers
Emre